### PR TITLE
Enlarge clickable area of icon with pseudo-element

### DIFF
--- a/web/collapsible.css
+++ b/web/collapsible.css
@@ -20,6 +20,15 @@
   filter: var(--green);
 }
 
+.collapse-icon::after {
+  position: absolute;
+  content: "";
+  width: 22px;
+  height: 22px;
+  left: -6px;
+  top: -3px;
+}
+
 .is-collapsed .collapse-icon {
   background-image: url('../icons/closed.png');
 }

--- a/web/collapsible.css
+++ b/web/collapsible.css
@@ -26,7 +26,7 @@
   width: 22px;
   height: 22px;
   left: -6px;
-  top: -3px;
+  top: -2px;
 }
 
 .is-collapsed .collapse-icon {


### PR DESCRIPTION
It's easy to miss `.collapse-icon`, so I thought enlarging its clickable area would make sense.

While a change in icon size could be controversial, an invisible ::after pseudo-element would elegantly fix the issue. Below is a comparison of the clickable areas between the current state and this PR:

![image](https://user-images.githubusercontent.com/62722460/118290202-71317600-b4d6-11eb-8fac-dd4469487277.png)

I made sure not to overlay the field names, but enlarged the area to the left side. The pseudo-elements don't overlap vertically, but align pixel-to-pixel.